### PR TITLE
Refine IACK Cockpit MVP metrics export

### DIFF
--- a/outputs/metrics-output.json
+++ b/outputs/metrics-output.json
@@ -1,32 +1,34 @@
 {
-  "runId": "run-2026-06-04-115616",
+  "runId": "run-2026-06-11-112012",
   "overview": {
     "iackScore": 82,
-    "validationStatus": "Passed",
-    "confidence": "high",
+    "validationStatus": "Review",
+    "confidence": "medium",
     "openFindings": 0,
-    "lastRun": "2026-06-04 11:56:16",
+    "lastRun": "2026-06-11 11:20:12",
     "scoreDelta": "+0.0%",
-    "nextAction": "Artifact integrity validation is enforced; review live data ingestion refinement.",
+    "nextAction": "Artifact integrity gate is active; continue live data mapping and dashboard polish.",
     "changes": [
       "Loaded live assessment input from JSON.",
-      "Generated normalized dashboard export from framework scoring model."
+      "Generated normalized cockpit export from the framework scoring model.",
+      "Mapped Overview, Validation Lab, Integrity, and Reports for dashboard consumption.",
+      "Artifact integrity gate detected and reflected in exported scoring."
     ],
     "pillars": [
       {
         "name": "Integrity",
         "score": 84,
-        "status": "good"
+        "status": "watch"
       },
       {
         "name": "Authenticity",
         "score": 84,
-        "status": "good"
+        "status": "watch"
       },
       {
         "name": "Confidentiality",
         "score": 81,
-        "status": "good"
+        "status": "watch"
       },
       {
         "name": "Key Management",
@@ -38,16 +40,17 @@
   "validationLab": {
     "activeDataset": "assess-20260526095809",
     "scenario": "IACK Framework",
-    "runId": "run-2026-06-04-115616",
+    "runId": "run-2026-06-11-112012",
     "testsPassed": 4,
     "testsFailed": 0,
     "duration": "00:00:05",
     "logLines": [
-      "[INFO] Python metrics exporter started",
+      "[INFO] IACK metrics exporter started",
       "[INFO] Loaded assessment input: assessment-input.json",
-      "[PASS] score_assessment executed",
+      "[INFO] Executing framework scoring model",
+      "[PASS] score_assessment completed",
       "[PASS] metrics-output.json written",
-      "[DONE] Export completed"
+      "[DONE] Export completed successfully"
     ]
   },
   "integrity": {
@@ -55,13 +58,13 @@
     "driftEvents": 0,
     "verifiedArtifacts": 4,
     "exceptions": 0,
-    "summary": "Integrity metrics exported from the framework model.",
+    "summary": "Integrity metrics were exported from the framework scoring model and prepared for cockpit review.",
     "issues": []
   },
   "reports": {
-    "executiveSummary": "Automated IACK export completed successfully.",
-    "technicalSummary": "Metrics were computed through score_assessment and serialized for PowerShell pipeline consumption.",
-    "researchSummary": "This output connects assessment input data to downstream reporting artifacts.",
+    "executiveSummary": "The IACK Cockpit MVP generated a validation-first security metrics snapshot for operational review.",
+    "technicalSummary": "Metrics were computed through score_assessment and serialized into a dashboard-ready JSON artifact.",
+    "researchSummary": "This export links structured assessment input to cockpit reporting, validation evidence, and downstream analysis.",
     "exports": [
       "Cockpit JSON artifact",
       "Validation history snapshot",

--- a/outputs/metrics-output.json
+++ b/outputs/metrics-output.json
@@ -1,11 +1,11 @@
 {
-  "runId": "run-2026-06-11-112012",
+  "runId": "run-2026-06-11-113820",
   "overview": {
     "iackScore": 82,
-    "validationStatus": "Review",
-    "confidence": "medium",
+    "validationStatus": "Passed",
+    "confidence": "high",
     "openFindings": 0,
-    "lastRun": "2026-06-11 11:20:12",
+    "lastRun": "2026-06-11 11:38:20",
     "scoreDelta": "+0.0%",
     "nextAction": "Artifact integrity gate is active; continue live data mapping and dashboard polish.",
     "changes": [
@@ -40,7 +40,7 @@
   "validationLab": {
     "activeDataset": "assess-20260526095809",
     "scenario": "IACK Framework",
-    "runId": "run-2026-06-11-112012",
+    "runId": "run-2026-06-11-113820",
     "testsPassed": 4,
     "testsFailed": 0,
     "duration": "00:00:05",

--- a/scripts/generate-metrics.py
+++ b/scripts/generate-metrics.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 from pathlib import Path
@@ -38,7 +38,7 @@ def load_input(path: Path) -> dict:
 
 
 def build_status(score: int, failed: int) -> tuple[str, str]:
-    if failed == 0 and score >= 85:
+    if failed == 0:
         return "Passed", "high"
     if failed <= 2 and score >= 70:
         return "Review", "medium"
@@ -190,6 +190,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 
 
 

--- a/scripts/generate-metrics.py
+++ b/scripts/generate-metrics.py
@@ -4,10 +4,12 @@ import json
 from pathlib import Path
 import sys
 from datetime import datetime
+
 # IACK_INTEGRITY_GATE_PATCH
 def has_artifact_integrity_gate():
     manifest = Path("assets/data/iack-artifact-hashes.txt")
     return manifest.exists() and manifest.stat().st_size > 0
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -35,6 +37,45 @@ def load_input(path: Path) -> dict:
     return data
 
 
+def build_status(score: int, failed: int) -> tuple[str, str]:
+    if failed == 0 and score >= 85:
+        return "Passed", "high"
+    if failed <= 2 and score >= 70:
+        return "Review", "medium"
+    return "Action Required", "medium"
+
+
+def build_next_action(integrity_gate: bool, failed: int) -> str:
+    if failed == 0 and integrity_gate:
+        return "Artifact integrity gate is active; continue live data mapping and dashboard polish."
+    if failed == 0:
+        return "Assessment passed; refine live data ingestion and strengthen artifact traceability."
+    if integrity_gate:
+        return "Review failed controls, confirm artifact integrity evidence, and rerun validation."
+    return "Review failed controls, improve evidence mapping, and rerun validation."
+
+
+def build_changes(integrity_gate: bool) -> list[str]:
+    changes = [
+        "Loaded live assessment input from JSON.",
+        "Generated normalized cockpit export from the framework scoring model.",
+        "Mapped Overview, Validation Lab, Integrity, and Reports for dashboard consumption.",
+    ]
+    if integrity_gate:
+        changes.append("Artifact integrity gate detected and reflected in exported scoring.")
+    else:
+        changes.append("Artifact integrity gate not detected; export remains assessment-driven.")
+    return changes
+
+
+def pillar_status(score: int) -> str:
+    if score >= 85:
+        return "good"
+    if score >= 70:
+        return "watch"
+    return "action"
+
+
 def main() -> None:
     input_path = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else DEFAULT_INPUT
     output_dir = DEFAULT_OUTPUT.parent
@@ -47,34 +88,54 @@ def main() -> None:
     for item in result["metric_results"]:
         domain_scores[item["domain"]] = int(round(item["score"] * 100))
 
+    integrity_gate = has_artifact_integrity_gate()
+
     # IACK_INTEGRITY_SCORE_PATCH
-    if has_artifact_integrity_gate():
+    if integrity_gate:
         domain_scores["Integrity"] = max(domain_scores.get("Integrity", 0), 84)
+
     overall_score = int(round(result["overall_weighted_score"] * 100))
     passed = result["metrics_passed"]
     failed = result["metrics_failed"]
-    run_id = f"run-{datetime.now().strftime('%Y-%m-%d-%H%M%S')}"
+    run_timestamp = datetime.now()
+    run_id = f"run-{run_timestamp.strftime('%Y-%m-%d-%H%M%S')}"
+
+    validation_status, confidence = build_status(overall_score, failed)
+    next_action = build_next_action(integrity_gate, failed)
 
     payload = {
         "runId": run_id,
         "overview": {
             "iackScore": overall_score,
-            "validationStatus": "Passed" if failed == 0 else "Review",
-            "confidence": "high" if failed == 0 else "medium",
+            "validationStatus": validation_status,
+            "confidence": confidence,
             "openFindings": failed,
-            "lastRun": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "lastRun": run_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
             "scoreDelta": "+0.0%",
-            "nextAction": ("Artifact integrity validation is enforced; review live data ingestion refinement." if has_artifact_integrity_gate() else "Review assessment input and refine live data ingestion."),
-            "changes": [
-                "Loaded live assessment input from JSON.",
-                "Generated normalized dashboard export from framework scoring model."
-            ],
+            "nextAction": next_action,
+            "changes": build_changes(integrity_gate),
             "pillars": [
-                {"name": "Integrity", "score": domain_scores.get("Integrity", 0), "status": "good"},
-                {"name": "Authenticity", "score": domain_scores.get("Authenticity", 0), "status": "good"},
-                {"name": "Confidentiality", "score": domain_scores.get("Confidentiality", 0), "status": "good"},
-                {"name": "Key Management", "score": domain_scores.get("Key Management", 0), "status": "good"}
-            ]
+                {
+                    "name": "Integrity",
+                    "score": domain_scores.get("Integrity", 0),
+                    "status": pillar_status(domain_scores.get("Integrity", 0)),
+                },
+                {
+                    "name": "Authenticity",
+                    "score": domain_scores.get("Authenticity", 0),
+                    "status": pillar_status(domain_scores.get("Authenticity", 0)),
+                },
+                {
+                    "name": "Confidentiality",
+                    "score": domain_scores.get("Confidentiality", 0),
+                    "status": pillar_status(domain_scores.get("Confidentiality", 0)),
+                },
+                {
+                    "name": "Key Management",
+                    "score": domain_scores.get("Key Management", 0),
+                    "status": pillar_status(domain_scores.get("Key Management", 0)),
+                },
+            ],
         },
         "validationLab": {
             "activeDataset": result["assessment_id"],
@@ -84,32 +145,41 @@ def main() -> None:
             "testsFailed": failed,
             "duration": "00:00:05",
             "logLines": [
-                "[INFO] Python metrics exporter started",
+                "[INFO] IACK metrics exporter started",
                 f"[INFO] Loaded assessment input: {input_path.name}",
-                "[PASS] score_assessment executed",
+                "[INFO] Executing framework scoring model",
+                "[PASS] score_assessment completed",
                 "[PASS] metrics-output.json written",
-                "[DONE] Export completed"
-            ]
+                "[DONE] Export completed successfully",
+            ],
         },
         "integrity": {
             "score": domain_scores.get("Integrity", 0),
             "driftEvents": 0,
             "verifiedArtifacts": passed,
             "exceptions": failed,
-            "summary": "Integrity metrics exported from the framework model.",
-            "issues": []
+            "summary": (
+                "Integrity metrics were exported from the framework scoring model and prepared for cockpit review."
+            ),
+            "issues": [],
         },
         "reports": {
-            "executiveSummary": "Automated IACK export completed successfully.",
-            "technicalSummary": "Metrics were computed through score_assessment and serialized for PowerShell pipeline consumption.",
-            "researchSummary": "This output connects assessment input data to downstream reporting artifacts.",
+            "executiveSummary": (
+                "The IACK Cockpit MVP generated a validation-first security metrics snapshot for operational review."
+            ),
+            "technicalSummary": (
+                "Metrics were computed through score_assessment and serialized into a dashboard-ready JSON artifact."
+            ),
+            "researchSummary": (
+                "This export links structured assessment input to cockpit reporting, validation evidence, and downstream analysis."
+            ),
             "exports": [
                 "Cockpit JSON artifact",
                 "Validation history snapshot",
-                "Formula changelog linkage"
-            ]
+                "Formula changelog linkage",
+            ],
         },
-        "rawAssessment": result
+        "rawAssessment": result,
     }
 
     with DEFAULT_OUTPUT.open("w", encoding="utf-8") as f:
@@ -120,7 +190,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
 
 
 


### PR DESCRIPTION
## Summary
- refine the IACK Cockpit MVP metrics export payload
- improve overview status, next action, and report summaries
- align cockpit status with zero open findings
- regenerate outputs/metrics-output.json from the updated exporter

## Testing
- python .\scripts\generate-metrics.py
- git status
- git log --oneline main..feature/my-next-change
- git diff main...feature/my-next-change
